### PR TITLE
docs: add house-style documentation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,136 @@
+# Advanced usage
+
+Recipes and sharp edges once you are past the [quickstart](quickstart.md).
+
+## Choosing a scoring strategy
+
+`get_sequence_prob` and `iterate_sequences` reduce a sequence's per-step weights
+into one number. The strategy decides how. `PROB_*` variants use probabilities
+(0–1 per step); the raw variants use integer transition counts.
+
+```python
+from markovjson import MarkovWordJson
+from markovjson.mkov import SequenceScoringStrategy as S
+
+w = MarkovWordJson(order=1)
+w.add_string("turn on the lights")
+w.add_string("turn off the lights")
+
+phrase = "turn on the lights"
+print(w.get_sequence_prob(phrase, strategy=S.PROB_MULTIPLY))   # product of step probs
+print(w.get_sequence_prob(phrase, strategy=S.PROB_AVERAGE))    # mean step prob
+print(w.get_sequence_prob(phrase, strategy=S.MIN))             # rarest raw transition
+```
+
+Rules of thumb:
+
+- `PROB_MULTIPLY` (default) punishes any single weak link — good for "is this whole
+  phrase well-formed?"
+- `PROB_AVERAGE` is forgiving of one odd step — good for fuzzy matching.
+- `MIN` / `MAX` on raw counts surface the rarest / most common single transition.
+
+## Setting the order
+
+`order` is the context window. Higher order means more faithful reproduction of the
+training data but sparser tables and less novelty.
+
+```python
+from markovjson import MarkovCharJson
+
+corpus = ["alice", "alma", "alva", "alan", "alba"]
+for order in (1, 2):
+    m = MarkovCharJson(order=order)
+    for name in corpus:
+        m.add_string(name)
+    print(order, m.generate_string(max_len=12))
+```
+
+Order 1 wanders; order 2 stays closer to the source spellings.
+
+## Reverse models
+
+Pass `reverse=True` to predict backwards — useful for completing the *start* of a
+sequence, or generating endings. The chain swaps the internal roles of the start
+and end markers; `generate_string` flips the output back to reading order for you.
+
+```python
+from markovjson import MarkovWordJson
+
+rev = MarkovWordJson(order=1, reverse=True)
+rev.add_string("please turn off the lights")
+rev.add_string("now turn off the lights")
+print(rev.generate_string(max_len=10))
+```
+
+## Wildcards for unseen tokens
+
+When scoring real-world input, tokens absent from training would make every
+sequence impossible. `wildcards=True` rewrites unknown tokens to the `[/]` marker
+so a partial match still scores:
+
+```python
+from markovjson import MarkovWordJson
+
+w = MarkovWordJson(order=1)
+w.add_string("turn on the lights")
+
+print(w.get_sequence_prob("please turn on the lights", wildcards=True))
+```
+
+Consecutive unknowns collapse to a single wildcard, so noise does not explode the
+state space.
+
+## Enumerating likely completions
+
+`iterate_sequences` yields complete `(sequence, score)` paths above `thresh`. Use
+it to list what a model considers plausible:
+
+```python
+from markovjson import MarkovWordJson
+
+w = MarkovWordJson(order=1)
+w.add_string("turn on the lights")
+w.add_string("turn off the lights")
+
+for seq, score in w.iterate_sequences(thresh=0.1):
+    words = [t for t in seq if not t.startswith("[/")]
+    print(round(score, 3), " ".join(words))
+```
+
+## POS tagging with Viterbi
+
+`MarkovNLPJson` learns transition *and* emission counts, so a trained model can tag
+new sentences with the Viterbi algorithm:
+
+```python
+from markovjson import MarkovNLPJson
+
+m = MarkovNLPJson(order=2)
+m.add_string("the cat sat on the mat")
+m.add_string("the dog ran on the road")
+
+print(m.viterbi_tagger("the cat ran"))   # [(word, tag), ...]
+```
+
+Unknown words fall back to `unknown_word_prob`; if the model has no tags at all,
+every token comes back tagged `"UNK"`.
+
+## Gotchas
+
+- **Tuple-key round-trip.** `save` stringifies the tuple state keys; `load` rebuilds
+  them by slicing those strings. Tokens containing `', '` can corrupt on reload.
+  Keep tokens free of that literal substring, or persist in a context where you
+  control the vocabulary.
+- **Tagged tokens are single-word.** `MarkovTaggerJson` stores `"<word> [/TAG=<tag>]"`
+  and `generate_tagged_string` splits on the last space — multi-word tokens are not
+  supported on that path.
+- **`generate_sequence` returns markers.** The raw list includes `[/START]` /
+  `[/END]`; filter them yourself, or use a subclass's `generate_string`.
+- **`normalize` returns a list.** Even given a single string,
+  `markovjson.nlp.normalize` returns a list of documents — index `[0]` for one.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — the core idea and first calls
+- [api.md](api.md) — full signatures and return shapes
+- [topic_modelling.md](topic_modelling.md) — intent classification on the chain

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,229 @@
+# API reference
+
+Public surface re-exported from `markovjson`:
+
+```python
+from markovjson import MarkovJson, MarkovCharJson, MarkovWordJson, MarkovNLPJson
+from markovjson.mkov import SequenceScoringStrategy
+from markovjson.topic_modelling import MarkovTopic, MarkovNLPTopic
+from markovjson.nlp import normalize, pos_tag
+```
+
+`MarkovJson`, `MarkovCharJson`, `MarkovWordJson`, and `MarkovNLPJson` are on the
+package root. `SequenceScoringStrategy`, the topic classes, and the NLP helpers
+live in their submodules.
+
+---
+
+## `MarkovJson`
+
+```python
+MarkovJson(order=1, reverse=False,
+           strategy=SequenceScoringStrategy.PROB_MULTIPLY)
+```
+
+The base chain. Tokenizes on whitespace by default; subclasses override
+`tokenize`.
+
+- `order` — number of previous tokens that make up a state.
+- `reverse` — train a reverse chain (predict the start from the end). Swaps the
+  internal meaning of the `[/START]` and `[/END]` markers.
+- `strategy` — default `SequenceScoringStrategy` used by `iterate_sequences` and
+  `__iter__`.
+
+### Training
+
+```python
+add_string(text) -> None
+add_tokens(tokens: list[str]) -> None
+add_state(current_state: tuple, next_state: str) -> None
+```
+
+`add_string` tokenizes then calls `add_tokens`, which pads with `order` start
+markers plus one end marker and increments every transition count. `add_state` is
+the single-transition primitive.
+
+### Tokenization
+
+```python
+tokenize(text, wildcards=False) -> list[str]
+replace_wildcards(sequence: list[str]) -> list[str]
+```
+
+`tokenize` splits on `" "` in the base class. With `wildcards=True`, tokens not
+seen in training collapse to the `[/]` wildcard marker (runs of unknowns collapse
+to a single wildcard).
+
+### Generation and sampling
+
+```python
+sample(current_state=None) -> str
+generate_sequence(max_len=100, initial_state=None, pad=False, retry=2) -> list[str]
+```
+
+`sample` draws one next token weighted by transition counts, returning the
+`[/NULL]` marker if the state is a dead end. `generate_sequence` repeatedly samples
+until it hits the end marker or `max_len`; if it dead-ends with no `initial_state`
+it restarts a fresh path up to `retry` times. The returned list still contains the
+`[/START]` / `[/END]` markers — subclasses' `generate_string` strips them.
+
+### Scoring
+
+```python
+get_state_probability(current_state: tuple, next_state: str) -> float
+get_transition_weights(sequence, wildcards=False) -> tuple[list[int], list[float]]
+get_sequence_prob(sequence,
+                  strategy=SequenceScoringStrategy.PROB_MULTIPLY,
+                  wildcards=False) -> float
+```
+
+`get_state_probability` is one transition's `count / total`. `get_transition_weights`
+returns `(raw_counts, probabilities)` for every step in a sequence.
+`get_sequence_prob` reduces those into a single number per the chosen strategy;
+it returns `0` for an impossible sequence.
+
+```python
+from markovjson import MarkovWordJson
+w = MarkovWordJson(order=1)
+w.add_string("turn on the lights")
+w.add_string("turn off the lights")
+print(w.get_sequence_prob("turn on the lights"))   # 0.5
+```
+
+### Enumerating paths
+
+```python
+iterate_sequences(initial_state=None, max_len=10, pad=False, strategy=None,
+                  max_depth=25, thresh=0.01) -> Iterator[tuple[list[str], float]]
+__iter__()   # iterate_sequences from the start state
+```
+
+Yields `(sequence, score)` pairs for complete paths whose score clears `thresh`.
+`max_depth` bounds the recursion; `max_len` bounds path length.
+
+### State helpers
+
+```python
+get_state(initial_state=None, pad=True) -> tuple
+state2sequence(initial_state, pad=False, wildcards=False) -> list[str]
+sequence2states(sequence, wildcards=False) -> list[tuple]
+```
+
+`tokens` (property) returns the unique token vocabulary seen in training.
+
+### Persistence
+
+```python
+save(filename) -> None
+load(filename) -> MarkovJson   # returns self
+```
+
+`save` serializes `order`, the sequence markers, `reverse_modelling`, and the
+transition table to JSON via `json_database`. `load` mutates the instance in place
+and returns it, so `MarkovWordJson(order=1).load("m.json")` works.
+
+### Removal scoring
+
+```python
+calc_approximate_removal_score(state, sequences=None, required_states=None,
+                               blacklisted_states=None, max_seqs=100,
+                               *args, **kwargs) -> float
+```
+
+A heuristic in `[0.0, 1.0]` for how much a single token (`state`) drives the
+high-probability paths of the model, optionally scoped to paths that must contain
+`required_states` and must not contain `blacklisted_states`. This is the engine
+behind [topic_modelling.md](topic_modelling.md).
+
+### `SequenceScoringStrategy`
+
+A `str` `Enum` of reducers for `get_sequence_prob`. Raw-count variants
+(`MAX`, `MIN`, `SUM`, `MULTIPLY`, `AVERAGE`) operate on integer transition counts;
+`PROB_*` variants operate on per-step probabilities:
+
+```python
+from markovjson.mkov import SequenceScoringStrategy
+SequenceScoringStrategy.PROB_MULTIPLY   # default
+# PROB_AVERAGE, PROB_MAX, PROB_MIN, PROB_SUM
+# MAX, MIN, SUM, MULTIPLY, AVERAGE
+```
+
+---
+
+## `MarkovCharJson(MarkovJson)`
+
+Character-level chain. `tokenize` splits into individual characters.
+
+```python
+generate_string(*args, **kwargs) -> str
+```
+
+Generates via `generate_sequence` and concatenates the characters (markers
+removed). Accepts the same kwargs as `generate_sequence` (`max_len`,
+`initial_state`, `pad`, `retry`).
+
+```python
+from markovjson import MarkovCharJson
+m = MarkovCharJson(order=2)
+for name in ["alice", "alma", "alva", "alan"]:
+    m.add_string(name)
+print(m.generate_string(max_len=10))
+```
+
+---
+
+## `MarkovWordJson(MarkovJson)`
+
+Word-level chain (inherits the whitespace `tokenize`).
+
+```python
+generate_string(*args, **kwargs) -> str   # joins tokens with " "
+```
+
+---
+
+## `MarkovNLPJson(MarkovWordJson)`
+
+POS-tagged chain. Tokens are `word [/TAG=POS]` strings produced by NLTK's
+`pos_tag`; the model also tracks per-tag emission counts so it can tag new text.
+
+```python
+MarkovNLPJson(normalize=False, wildcard_postags=None, *args, **kwargs)
+```
+
+- `normalize` — lemmatize/clean text (via `markovjson.nlp.normalize`) before tagging.
+- `wildcard_postags` — list of POS tags to treat as wildcards.
+
+```python
+viterbi_tagger(sentence, unknown_word_prob=1e-10) -> list[tuple[str, str]]
+generate_string(*args, **kwargs) -> str                 # words only, tags dropped
+generate_tagged_string(*args, **kwargs) -> list[tuple[str, str]]
+```
+
+`viterbi_tagger` returns the most likely `(word, tag)` sequence for a sentence
+using the trained transition + emission probabilities. `generate_tagged_string`
+returns generated output as `(word, tag)` tuples.
+
+`MarkovNLPJson` subclasses `MarkovTaggerJson` (in `markovjson.tokenizers`), which
+is the generic version taking any `tagger` callable. `MarkovNLPJson` wires in the
+NLTK tagger for you.
+
+---
+
+## NLP helpers (`markovjson.nlp`)
+
+```python
+normalize(X, stemmer=None, lemmatize=True) -> list[str]
+pos_tag(sentence) -> list[tuple[str, str]]
+```
+
+`normalize` strips special characters, lowercases, and lemmatizes (WordNet by
+default) — it always returns a *list* of cleaned documents, even for a single
+string input. `pos_tag` wraps NLTK tokenize + tag and self-downloads the required
+corpora on first use.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and the core idea
+- [advanced.md](advanced.md) — strategies, reverse models, wildcards, gotchas
+- [topic_modelling.md](topic_modelling.md) — `MarkovTopic` for intent classification

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart — markovjson in five minutes
+
+`markovjson` builds order-N Markov chains over tokens and persists them as plain
+JSON. You pick how text becomes tokens — characters, words, or POS-tagged words —
+and the same chain machinery generates new sequences, scores existing ones, and
+saves to disk.
+
+## 1. Install
+
+```bash
+pip install markovjson
+```
+
+Pulls in `json_database` (JSON persistence) and `nltk` (POS tagging,
+lemmatization). NLTK corpora (`punkt`, `averaged_perceptron_tagger`, `wordnet`,
+`stopwords`) download themselves the first time you use the NLP path.
+
+## 2. The one idea
+
+A model keeps a table of *states* → *next-token counts*. A state is a tuple of the
+last `order` tokens. Training just walks your text and increments those counts;
+generation walks the table back the other way, sampling the next token by weight.
+
+Every model is a `MarkovJson` underneath. The subclass you choose only decides how
+a string splits into tokens and how a sequence joins back into a string:
+
+| Class | Token unit | Joins with |
+| --- | --- | --- |
+| `MarkovCharJson` | one character | `""` |
+| `MarkovWordJson` | one space-split word | `" "` |
+| `MarkovNLPJson` | a `word [/TAG=POS]` pair | `" "` (tag stripped) |
+
+## 3. First real model
+
+Train a character model on a handful of names and sample a new one:
+
+```python
+from markovjson import MarkovCharJson
+
+m = MarkovCharJson(order=2)
+for name in ["alice", "alma", "alva", "alan"]:
+    m.add_string(name)
+
+print(m.generate_string(max_len=10))   # e.g. "alan" — a plausible new name
+```
+
+`add_string` tokenizes and trains. `generate_string` samples a fresh sequence and
+joins it for you, dropping the internal `[/START]` / `[/END]` markers.
+
+## 4. Score instead of generate
+
+The same chain tells you how likely an existing sequence is. Train two intents and
+ask which transitions a phrase took:
+
+```python
+from markovjson import MarkovWordJson
+
+w = MarkovWordJson(order=1)
+w.add_string("turn on the lights")
+w.add_string("turn off the lights")
+
+print(w.get_sequence_prob("turn on the lights"))   # 0.5
+```
+
+The `0.5` is the product of per-transition probabilities: `turn` splits evenly
+between `on` and `off`, everything else is deterministic.
+
+## 5. Save and reload
+
+Models round-trip through JSON, so a trained chain is a portable artifact:
+
+```python
+from markovjson import MarkovWordJson
+
+w = MarkovWordJson(order=1)
+w.add_string("turn on the lights")
+w.save("lights.json")
+
+reloaded = MarkovWordJson(order=1).load("lights.json")
+print(reloaded.records)
+```
+
+`save` writes the order, the sequence markers, and the transition table. `load`
+returns `self`, so you can chain it onto a constructor as above.
+
+## Where next
+
+- [api.md](api.md) — every public class, method, kwarg, and return shape
+- [advanced.md](advanced.md) — scoring strategies, reverse models, wildcards, gotchas
+- [topic_modelling.md](topic_modelling.md) — intent/topic classification on top of the chain

--- a/docs/topic_modelling.md
+++ b/docs/topic_modelling.md
@@ -1,0 +1,94 @@
+# Topic and intent modelling
+
+`MarkovTopic` turns the chain into a lightweight text classifier. It trains one
+shared model over labelled samples and scores how strongly a document's tokens
+point at each label — no separate model per class, no feature engineering.
+
+```python
+from markovjson.topic_modelling import MarkovTopic, MarkovNLPTopic
+```
+
+## How it works
+
+Each training sample is wrapped in a label marker, e.g. `[/LABEL=lights_off]`, on
+both ends before being added to the chain. Classification then asks, per label, how
+much each input token drives the high-probability paths scoped to that label — the
+[`calc_approximate_removal_score`](api.md#removal-scoring) heuristic. A token that
+only appears under one label scores near `1.0` there and `0.0` elsewhere.
+
+## Register topics and predict
+
+```python
+from markovjson.topic_modelling import MarkovTopic
+
+clf = MarkovTopic(order=2)
+clf.register_topic("on", ["turn on the lights", "lights on"])
+clf.register_topic("off", ["turn off the lights", "lights off"])
+
+print(clf.predict_topic("turn off"))
+# {'[/LABEL=on]': 0.4, '[/LABEL=off]': 0.7}
+```
+
+`register_topic(topic_name, samples)` adds a list of strings under one label.
+`predict_topic(document, thresh=0.3)` returns the labels whose mean token score
+clears `thresh`. Labels come back in their internal `[/LABEL=<name>]` form.
+
+## Train from files
+
+One file per intent, one sample per line — the file's basename becomes the label
+unless you pass `topic_name`:
+
+```python
+from markovjson.topic_modelling import MarkovTopic
+
+clf = MarkovTopic(order=4)
+clf.register_topic_from_file("intents/lights_on.txt")
+clf.register_topic_from_file("intents/lights_off.txt", topic_name="off")
+```
+
+## Inspect the per-token scores
+
+`predict_topic` averages token scores; to see them individually use `score_tokens`
+(all labels) or `score_topic` (one label):
+
+```python
+from markovjson.topic_modelling import MarkovTopic
+
+clf = MarkovTopic(order=2)
+clf.register_topic("on", ["turn on the lights", "lights on"])
+clf.register_topic("off", ["turn off the lights", "lights off"])
+
+from pprint import pprint
+pprint(clf.score_tokens("turn off"))
+# per-label dict of {token: score}
+```
+
+This breakdown shows *which* words pushed a prediction, handy for debugging why an
+utterance landed on a label.
+
+## API
+
+```python
+MarkovTopic(ignore_case=True, *args, **kwargs)   # *args/**kwargs pass to MarkovWordJson
+
+register_topic(topic_name, samples) -> None
+register_topic_from_file(path, topic_name=None) -> None
+score_topic(topic, document, wildcards=True) -> dict[str, float]
+score_tokens(document, wildcards=True) -> dict[str, dict[str, float]]
+predict_topic(document, thresh=0.3, wildcards=True) -> dict[str, float]
+```
+
+- `ignore_case` lowercases samples on registration.
+- `wildcards=True` (the default here) lets unseen input words still score against
+  the model rather than zeroing the sequence — see
+  [advanced.md](advanced.md#wildcards-for-unseen-tokens).
+
+`MarkovNLPTopic` mixes `MarkovTopic` with `MarkovNLPJson`, so topics are learned
+over POS-tagged tokens instead of bare words — reach for it when grammar, not just
+vocabulary, separates your intents.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — the core chain idea
+- [api.md](api.md) — `calc_approximate_removal_score` and the base chain
+- [advanced.md](advanced.md) — wildcards, ordering, scoring strategies


### PR DESCRIPTION
Adds a `docs/` directory covering the public API.

- `quickstart.md` — install, the core chain idea, first char/word models, scoring, save/load.
- `api.md` — every public class, method, kwarg, and return shape across `MarkovJson`, the tokenizer subclasses, `SequenceScoringStrategy`, and the NLP helpers.
- `advanced.md` — scoring strategies, model order, reverse models, wildcards, path enumeration, Viterbi tagging, and gotchas.
- `topic_modelling.md` — `MarkovTopic` / `MarkovNLPTopic` for intent classification.

Pages cross-link and every Python snippet runs against the package source. Scope is `docs/` only; `examples/` is untouched.