### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,81 @@
 
 # MarkovJson
 
-A Python library for creating, training, and utilizing Markov chain models with a focus on JSON-based persistence, flexible tokenization, and advanced analytical capabilities.
+MarkovJson is a Python library for Markov chain models over text. It builds
+order-N chains from tokens, saves and loads them as JSON, and supports
+character-level, word-level, and POS-tagged tokenization. On top of the chain,
+it adds sequence scoring, topic and intent classification, and a heuristic
+score for how much a single token drives a model's high-probability paths.
 
 ## Features
 
-- Flexible Tokenization: Supports character-level (MarkovCharJson), word-level (MarkovWordJson), and advanced NLP-based tokenization with Part-of-Speech tagging (MarkovNLPJson).
-- Configurable Order: Easily adjust the order of the Markov model to control the complexity of the generated sequences.
-- Topic Modeling: The MarkovTopic class provides a simple yet effective way to train a model on labeled data and predict the topic of new text.
-- State Removal Scoring: Calculates a heuristic score to measure the impact of a state (a token) on the overall model, useful for identifying key tokens.
-- JSON Persistence: Models can be easily saved to and loaded from JSON files, making them portable and reusable.
-- Reverse Modeling: Supports reverse Markov chains for applications like predicting the end of a sequence.
+- Flexible tokenization: character-level (`MarkovCharJson`), word-level
+  (`MarkovWordJson`), and NLP tokenization with part-of-speech tagging
+  (`MarkovNLPJson`).
+- Configurable order: set how many previous tokens make up a state, to
+  control the complexity of generated sequences.
+- Topic modeling: `MarkovTopic` trains one shared model on labeled samples
+  and predicts the topic of new text.
+- Removal scoring: `calc_approximate_removal_score` measures how much a
+  single state (token) drives a model, useful for finding key tokens.
+- JSON persistence: save a model to a JSON file and load it back, so trained
+  models are portable.
+- Reverse modeling: train a reverse chain to predict the start of a sequence
+  from its end.
 
-## Installation
+## Install
 
-`pip install markovjson`
+```bash
+pip install markovjson
+```
 
+This pulls in [json_database](https://github.com/TigreGotico/json_database)
+for JSON persistence, and `nltk` for POS tagging and lemmatization. NLTK
+corpora (`punkt`, `averaged_perceptron_tagger`, `wordnet`, `stopwords`)
+download on first use of the NLP path.
+
+## Usage
+
+Train a character-level model on a few names and generate a new one:
+
+```python
+from markovjson import MarkovCharJson
+
+m = MarkovCharJson(order=2)
+for name in ["alice", "alma", "alva", "alan"]:
+    m.add_string(name)
+
+print(m.generate_string(max_len=10))   # e.g. "alan"
+```
+
+Score how likely an existing sequence is:
+
+```python
+from markovjson import MarkovWordJson
+
+w = MarkovWordJson(order=1)
+w.add_string("turn on the lights")
+w.add_string("turn off the lights")
+
+print(w.get_sequence_prob("turn on the lights"))   # 0.5
+```
+
+See the docs for more:
+
+- [Quickstart](docs/quickstart.md): install and the core idea
+- [API reference](docs/api.md): every public class, method, kwarg, and return shape
+- [Advanced usage](docs/advanced.md): scoring strategies, reverse models, wildcards, gotchas
+- [Topic and intent modelling](docs/topic_modelling.md): intent and topic classification on the chain
+
+## Related projects
+
+- [json_database](https://github.com/TigreGotico/json_database): the JSON
+  persistence layer MarkovJson uses to save and load models.
+- [ovos-markov-chat-plugin](https://github.com/TigreGotico/ovos-markov-chat-plugin):
+  Markov chain chat agent for OVOS personas, built on this library.
+- [ovos-markov-pipeline-plugin](https://github.com/TigreGotico/ovos-markov-pipeline-plugin):
+  OVOS intent pipeline plugin using Markov chain perplexity ensemble.
+
+## License
+
+Apache License 2.0.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -6,7 +6,7 @@ Recipes and sharp edges once you are past the [quickstart](quickstart.md).
 
 `get_sequence_prob` and `iterate_sequences` reduce a sequence's per-step weights
 into one number. The strategy decides how. `PROB_*` variants use probabilities
-(0–1 per step); the raw variants use integer transition counts.
+(0-1 per step). The raw variants use integer transition counts.
 
 ```python
 from markovjson import MarkovWordJson
@@ -24,9 +24,9 @@ print(w.get_sequence_prob(phrase, strategy=S.MIN))             # rarest raw tran
 
 Rules of thumb:
 
-- `PROB_MULTIPLY` (default) punishes any single weak link — good for "is this whole
+- `PROB_MULTIPLY` (default) punishes any single weak link: good for "is this whole
   phrase well-formed?"
-- `PROB_AVERAGE` is forgiving of one odd step — good for fuzzy matching.
+- `PROB_AVERAGE` is forgiving of one odd step: good for fuzzy matching.
 - `MIN` / `MAX` on raw counts surface the rarest / most common single transition.
 
 ## Setting the order
@@ -45,13 +45,13 @@ for order in (1, 2):
     print(order, m.generate_string(max_len=12))
 ```
 
-Order 1 wanders; order 2 stays closer to the source spellings.
+Order 1 wanders. Order 2 stays closer to the source spellings.
 
 ## Reverse models
 
-Pass `reverse=True` to predict backwards — useful for completing the *start* of a
+Pass `reverse=True` to predict backwards: useful for completing the *start* of a
 sequence, or generating endings. The chain swaps the internal roles of the start
-and end markers; `generate_string` flips the output back to reading order for you.
+and end markers. `generate_string` flips the output back to reading order for you.
 
 ```python
 from markovjson import MarkovWordJson
@@ -112,25 +112,22 @@ m.add_string("the dog ran on the road")
 print(m.viterbi_tagger("the cat ran"))   # [(word, tag), ...]
 ```
 
-Unknown words fall back to `unknown_word_prob`; if the model has no tags at all,
+Unknown words fall back to `unknown_word_prob`. If the model has no tags at all,
 every token comes back tagged `"UNK"`.
 
 ## Gotchas
 
-- **Tuple-key round-trip.** `save` stringifies the tuple state keys; `load` rebuilds
+- **Tuple-key round-trip.** `save` stringifies the tuple state keys. `load` rebuilds
   them by slicing those strings. Tokens containing `', '` can corrupt on reload.
   Keep tokens free of that literal substring, or persist in a context where you
   control the vocabulary.
 - **Tagged tokens are single-word.** `MarkovTaggerJson` stores `"<word> [/TAG=<tag>]"`
-  and `generate_tagged_string` splits on the last space — multi-word tokens are not
+  and `generate_tagged_string` splits on the last space. Multi-word tokens are not
   supported on that path.
 - **`generate_sequence` returns markers.** The raw list includes `[/START]` /
-  `[/END]`; filter them yourself, or use a subclass's `generate_string`.
+  `[/END]`. Filter them yourself, or use a subclass's `generate_string`.
 - **`normalize` returns a list.** Even given a single string,
-  `markovjson.nlp.normalize` returns a list of documents — index `[0]` for one.
+  `markovjson.nlp.normalize` returns a list of documents: index `[0]` for one.
 
-## Where next
-
-- [quickstart.md](quickstart.md) — the core idea and first calls
-- [api.md](api.md) — full signatures and return shapes
-- [topic_modelling.md](topic_modelling.md) — intent classification on the chain
+---
+[← API reference](api.md) · [Home](../README.md) · [Topic and intent modelling →](topic_modelling.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,13 +22,13 @@ MarkovJson(order=1, reverse=False,
            strategy=SequenceScoringStrategy.PROB_MULTIPLY)
 ```
 
-The base chain. Tokenizes on whitespace by default; subclasses override
+The base chain. It tokenizes on whitespace by default. Subclasses override
 `tokenize`.
 
-- `order` — number of previous tokens that make up a state.
-- `reverse` — train a reverse chain (predict the start from the end). Swaps the
+- `order`: number of previous tokens that make up a state.
+- `reverse`: train a reverse chain (predict the start from the end). Swaps the
   internal meaning of the `[/START]` and `[/END]` markers.
-- `strategy` — default `SequenceScoringStrategy` used by `iterate_sequences` and
+- `strategy`: default `SequenceScoringStrategy` used by `iterate_sequences` and
   `__iter__`.
 
 ### Training
@@ -63,9 +63,9 @@ generate_sequence(max_len=100, initial_state=None, pad=False, retry=2) -> list[s
 
 `sample` draws one next token weighted by transition counts, returning the
 `[/NULL]` marker if the state is a dead end. `generate_sequence` repeatedly samples
-until it hits the end marker or `max_len`; if it dead-ends with no `initial_state`
+until it hits the end marker or `max_len`. If it dead-ends with no `initial_state`,
 it restarts a fresh path up to `retry` times. The returned list still contains the
-`[/START]` / `[/END]` markers — subclasses' `generate_string` strips them.
+`[/START]` / `[/END]` markers: subclasses' `generate_string` strips them.
 
 ### Scoring
 
@@ -79,8 +79,8 @@ get_sequence_prob(sequence,
 
 `get_state_probability` is one transition's `count / total`. `get_transition_weights`
 returns `(raw_counts, probabilities)` for every step in a sequence.
-`get_sequence_prob` reduces those into a single number per the chosen strategy;
-it returns `0` for an impossible sequence.
+`get_sequence_prob` reduces those into a single number per the chosen strategy.
+It returns `0` for an impossible sequence.
 
 ```python
 from markovjson import MarkovWordJson
@@ -99,7 +99,7 @@ __iter__()   # iterate_sequences from the start state
 ```
 
 Yields `(sequence, score)` pairs for complete paths whose score clears `thresh`.
-`max_depth` bounds the recursion; `max_len` bounds path length.
+`max_depth` bounds the recursion. `max_len` bounds path length.
 
 ### State helpers
 
@@ -138,7 +138,7 @@ behind [topic_modelling.md](topic_modelling.md).
 ### `SequenceScoringStrategy`
 
 A `str` `Enum` of reducers for `get_sequence_prob`. Raw-count variants
-(`MAX`, `MIN`, `SUM`, `MULTIPLY`, `AVERAGE`) operate on integer transition counts;
+(`MAX`, `MIN`, `SUM`, `MULTIPLY`, `AVERAGE`) operate on integer transition counts.
 `PROB_*` variants operate on per-step probabilities:
 
 ```python
@@ -185,14 +185,14 @@ generate_string(*args, **kwargs) -> str   # joins tokens with " "
 ## `MarkovNLPJson(MarkovWordJson)`
 
 POS-tagged chain. Tokens are `word [/TAG=POS]` strings produced by NLTK's
-`pos_tag`; the model also tracks per-tag emission counts so it can tag new text.
+`pos_tag`. The model also tracks per-tag emission counts so it can tag new text.
 
 ```python
 MarkovNLPJson(normalize=False, wildcard_postags=None, *args, **kwargs)
 ```
 
-- `normalize` — lemmatize/clean text (via `markovjson.nlp.normalize`) before tagging.
-- `wildcard_postags` — list of POS tags to treat as wildcards.
+- `normalize`: lemmatize/clean text (via `markovjson.nlp.normalize`) before tagging.
+- `wildcard_postags`: list of POS tags to treat as wildcards.
 
 ```python
 viterbi_tagger(sentence, unknown_word_prob=1e-10) -> list[tuple[str, str]]
@@ -218,12 +218,9 @@ pos_tag(sentence) -> list[tuple[str, str]]
 ```
 
 `normalize` strips special characters, lowercases, and lemmatizes (WordNet by
-default) — it always returns a *list* of cleaned documents, even for a single
+default): it always returns a *list* of cleaned documents, even for a single
 string input. `pos_tag` wraps NLTK tokenize + tag and self-downloads the required
 corpora on first use.
 
-## Where next
-
-- [quickstart.md](quickstart.md) — install and the core idea
-- [advanced.md](advanced.md) — strategies, reverse models, wildcards, gotchas
-- [topic_modelling.md](topic_modelling.md) — `MarkovTopic` for intent classification
+---
+[← Quickstart](quickstart.md) · [Home](../README.md) · [Advanced usage →](advanced.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,8 @@
-# Quickstart — markovjson in five minutes
+# Quickstart: markovjson in five minutes
 
 `markovjson` builds order-N Markov chains over tokens and persists them as plain
-JSON. You pick how text becomes tokens — characters, words, or POS-tagged words —
-and the same chain machinery generates new sequences, scores existing ones, and
+JSON. You pick how text becomes tokens: characters, words, or POS-tagged words.
+The same chain machinery generates new sequences, scores existing ones, and
 saves to disk.
 
 ## 1. Install
@@ -18,8 +18,8 @@ lemmatization). NLTK corpora (`punkt`, `averaged_perceptron_tagger`, `wordnet`,
 ## 2. The one idea
 
 A model keeps a table of *states* → *next-token counts*. A state is a tuple of the
-last `order` tokens. Training just walks your text and increments those counts;
-generation walks the table back the other way, sampling the next token by weight.
+last `order` tokens. Training walks your text and increments those counts.
+Generation walks the table back the other way, sampling the next token by weight.
 
 Every model is a `MarkovJson` underneath. The subclass you choose only decides how
 a string splits into tokens and how a sequence joins back into a string:
@@ -41,7 +41,7 @@ m = MarkovCharJson(order=2)
 for name in ["alice", "alma", "alva", "alan"]:
     m.add_string(name)
 
-print(m.generate_string(max_len=10))   # e.g. "alan" — a plausible new name
+print(m.generate_string(max_len=10))   # e.g. "alan": a plausible new name
 ```
 
 `add_string` tokenizes and trains. `generate_string` samples a fresh sequence and
@@ -83,8 +83,5 @@ print(reloaded.records)
 `save` writes the order, the sequence markers, and the transition table. `load`
 returns `self`, so you can chain it onto a constructor as above.
 
-## Where next
-
-- [api.md](api.md) — every public class, method, kwarg, and return shape
-- [advanced.md](advanced.md) — scoring strategies, reverse models, wildcards, gotchas
-- [topic_modelling.md](topic_modelling.md) — intent/topic classification on top of the chain
+---
+[Home](../README.md) · [API reference →](api.md)

--- a/docs/topic_modelling.md
+++ b/docs/topic_modelling.md
@@ -2,7 +2,7 @@
 
 `MarkovTopic` turns the chain into a lightweight text classifier. It trains one
 shared model over labelled samples and scores how strongly a document's tokens
-point at each label — no separate model per class, no feature engineering.
+point at each label: no separate model per class, no feature engineering.
 
 ```python
 from markovjson.topic_modelling import MarkovTopic, MarkovNLPTopic
@@ -12,7 +12,7 @@ from markovjson.topic_modelling import MarkovTopic, MarkovNLPTopic
 
 Each training sample is wrapped in a label marker, e.g. `[/LABEL=lights_off]`, on
 both ends before being added to the chain. Classification then asks, per label, how
-much each input token drives the high-probability paths scoped to that label — the
+much each input token drives the high-probability paths scoped to that label: the
 [`calc_approximate_removal_score`](api.md#removal-scoring) heuristic. A token that
 only appears under one label scores near `1.0` there and `0.0` elsewhere.
 
@@ -35,7 +35,7 @@ clears `thresh`. Labels come back in their internal `[/LABEL=<name>]` form.
 
 ## Train from files
 
-One file per intent, one sample per line — the file's basename becomes the label
+One file per intent, one sample per line: the file's basename becomes the label
 unless you pass `topic_name`:
 
 ```python
@@ -48,7 +48,7 @@ clf.register_topic_from_file("intents/lights_off.txt", topic_name="off")
 
 ## Inspect the per-token scores
 
-`predict_topic` averages token scores; to see them individually use `score_tokens`
+`predict_topic` averages token scores. To see them individually, use `score_tokens`
 (all labels) or `score_topic` (one label):
 
 ```python
@@ -80,15 +80,12 @@ predict_topic(document, thresh=0.3, wildcards=True) -> dict[str, float]
 
 - `ignore_case` lowercases samples on registration.
 - `wildcards=True` (the default here) lets unseen input words still score against
-  the model rather than zeroing the sequence — see
+  the model rather than zeroing the sequence: see
   [advanced.md](advanced.md#wildcards-for-unseen-tokens).
 
 `MarkovNLPTopic` mixes `MarkovTopic` with `MarkovNLPJson`, so topics are learned
-over POS-tagged tokens instead of bare words — reach for it when grammar, not just
+over POS-tagged tokens instead of bare words: reach for it when grammar, not just
 vocabulary, separates your intents.
 
-## Where next
-
-- [quickstart.md](quickstart.md) — the core chain idea
-- [api.md](api.md) — `calc_approximate_removal_score` and the base chain
-- [advanced.md](advanced.md) — wildcards, ordering, scoring strategies
+---
+[← Advanced usage](advanced.md) · [Home](../README.md)


### PR DESCRIPTION
Rewrites the README with a plain what-it-is summary, install, and usage examples, adds a related-projects section linking json_database and the OVOS Markov plugins, and adds a license section. The four docs pages get the same STE-flavored pass plus a standard prev/home/next footer replacing their ad hoc "Where next" lists.

Rewritten with Claude Fable 5 using the ste-writing skill; linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with a comprehensive project overview, installation guidance, usage examples, related projects, and license information.
  * Improved API, quickstart, advanced usage, and topic modeling documentation with clearer formatting, explanations, and navigation links.
  * Added examples covering character- and word-level models, training, generation, and sequence scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->